### PR TITLE
feat: Animated token movement, add keyboard nav, color-code effect badge

### DIFF
--- a/src/components/board/Board.css
+++ b/src/components/board/Board.css
@@ -62,6 +62,12 @@
     font-size: 24px;
     align-self: center;
     margin-bottom: 5px;
+    animation: tokenAppear 0.12s ease-out;
+}
+
+@keyframes tokenAppear {
+    from { transform: scale(0.4); opacity: 0; }
+    to   { transform: scale(1);   opacity: 1; }
 }
 
 /* Mobile */

--- a/src/components/dice/Dice.tsx
+++ b/src/components/dice/Dice.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { forwardRef, useImperativeHandle, useState } from "react";
 import "./Dice.css";
 
 // Import all dice images
@@ -9,60 +9,68 @@ import dice4 from "../../assets/4_dice.png";
 import dice5 from "../../assets/5_dice.png";
 import dice6 from "../../assets/6_dice.png";
 
-const Dice = ({ onRoll, disabled }: { onRoll: (value: number) => void; disabled?: boolean }) => {
-    const [diceValue, setDiceValue] = useState(1);
-    const [isRolling, setIsRolling] = useState(false);
+export interface DiceRef {
+    roll: () => void;
+}
 
-    const rollDice = () => {
-        if (isRolling || disabled) return;
+const Dice = forwardRef<DiceRef, { onRoll: (value: number) => void; disabled?: boolean }>(
+    ({ onRoll, disabled }, ref) => {
+        const [diceValue, setDiceValue] = useState(1);
+        const [isRolling, setIsRolling] = useState(false);
 
-        const finalValue = Math.floor(Math.random() * 6) + 1;
-        setIsRolling(true);
+        const rollDice = () => {
+            if (isRolling || disabled) return;
 
-        let cycles = 0;
-        const interval = setInterval(() => {
-            setDiceValue(Math.floor(Math.random() * 6) + 1);
-            cycles++;
-            if (cycles >= 10) {
-                clearInterval(interval);
-                setDiceValue(finalValue);
-                onRoll(finalValue);
-                setIsRolling(false);
-            }
-        }, 80);
-    };
+            const finalValue = Math.floor(Math.random() * 6) + 1;
+            setIsRolling(true);
 
-    // Map dice value to respective images
-    const diceImages: { [key: number]: string } = {
-        1: dice1,
-        2: dice2,
-        3: dice3,
-        4: dice4,
-        5: dice5,
-        6: dice6,
-    };
+            let cycles = 0;
+            const interval = setInterval(() => {
+                setDiceValue(Math.floor(Math.random() * 6) + 1);
+                cycles++;
+                if (cycles >= 10) {
+                    clearInterval(interval);
+                    setDiceValue(finalValue);
+                    onRoll(finalValue);
+                    setIsRolling(false);
+                }
+            }, 80);
+        };
 
-    return (
-        <div className="dice-container">
-            <div className="dice-images">
-                {[1, 2, 3, 4, 5, 6].map((value) => (
-                    <img
-                        key={value}
-                        src={diceImages[value]}
-                        alt={`Dice showing ${value}`}
-                        className={`dice-image ${diceValue === value ? `visible${isRolling ? " rolling" : ""}` : "hidden"}`}
-                    />
-                ))}
+        useImperativeHandle(ref, () => ({ roll: rollDice }));
+
+        // Map dice value to respective images
+        const diceImages: { [key: number]: string } = {
+            1: dice1,
+            2: dice2,
+            3: dice3,
+            4: dice4,
+            5: dice5,
+            6: dice6,
+        };
+
+        return (
+            <div className="dice-container">
+                <div className="dice-images">
+                    {[1, 2, 3, 4, 5, 6].map((value) => (
+                        <img
+                            key={value}
+                            src={diceImages[value]}
+                            alt={`Dice showing ${value}`}
+                            className={`dice-image ${diceValue === value ? `visible${isRolling ? " rolling" : ""}` : "hidden"}`}
+                        />
+                    ))}
+                </div>
+                <button
+                    className="dice-button"
+                    onClick={rollDice}
+                    disabled={isRolling || disabled}
+                >
+                    Tirar el dado!
+                </button>
             </div>
-            <button
-                className="dice-button"
-                onClick={rollDice}
-                disabled={isRolling || disabled}
-            >
-                Tirar el dado!
-            </button>
-        </div>
-    );
-};
+        );
+    }
+);
 
 export default Dice;

--- a/src/pages/BoardGame.css
+++ b/src/pages/BoardGame.css
@@ -109,11 +109,18 @@
     padding-bottom: 8px;
 }
 
-.markdown-tag {
-    font-size: 0.8em;
-    color: #333;
-    align-self: flex-end;
+.effect-badge {
+    margin-top: 12px;
+    padding: 2px 12px;
+    border-radius: 6px;
+    border-left: 4px solid;
+    font-size: 0.85em;
 }
+
+.effect-badge--forward  { background: #d4edda; border-color: #28a745; color: #155724; }
+.effect-badge--backward { background: #f8d7da; border-color: #dc3545; color: #721c24; }
+.effect-badge--skip     { background: #e2e3e5; border-color: #6c757d; color: #383d41; }
+.effect-badge--finish   { background: #cce5ff; border-color: #004085; color: #004085; }
 
 .board-wrapper {
     flex: 1;

--- a/src/pages/BoardGame.tsx
+++ b/src/pages/BoardGame.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
 import Board from "../components/board/Board";
-import Dice from "../components/dice/Dice";
+import Dice, { DiceRef } from "../components/dice/Dice";
 import Modal from "../components/modal/Modal";
 import tilesData from "../data/tiles.json";
 
@@ -13,56 +13,60 @@ import ReactMarkdown from "react-markdown";
 
 function BoardGame() {
     // States
-    const [playerPosition, setPlayerPosition] = useState(1);
+    const [targetPosition, setTargetPosition] = useState(1);
+    const [displayPosition, setDisplayPosition] = useState(1);
     const [currentTileTitle, setCurrentTileTitle] = useState<string>("");
     const [currentTileDescription, setCurrentTileDescription] = useState<string>("");
     const [currentTileEffectText, setCurrentTileEffectText] = useState<string | undefined>(undefined);
     const [currentTileEffect, setCurrentTileEffect] = useState<string | null | undefined>(null);
     const [isModalOpen, setIsModalOpen] = useState(false);
 
+    const diceRef = useRef<DiceRef>(null);
 
-    // Effects 
-
+    // Token animation: step one tile toward target every 150ms, then open modal
     useEffect(() => {
-        const currentTile = tilesData.tiles.find(tile => tile.id === playerPosition);
-        if (currentTile) {
-            setCurrentTileTitle(currentTile.title);
-            setCurrentTileDescription(currentTile.description);
-            setCurrentTileEffectText(currentTile.effectDescription);
-            setCurrentTileEffect(currentTile.effect);
-            setIsModalOpen(true);
+        if (displayPosition === targetPosition) {
+            const tile = tilesData.tiles.find(t => t.id === displayPosition);
+            if (tile) {
+                setCurrentTileTitle(tile.title);
+                setCurrentTileDescription(tile.description);
+                setCurrentTileEffectText(tile.effectDescription);
+                setCurrentTileEffect(tile.effect);
+                setIsModalOpen(true);
+            }
+            return;
         }
-    }, [playerPosition]);
+        const dir = targetPosition > displayPosition ? 1 : -1;
+        const timer = setTimeout(() => setDisplayPosition(prev => prev + dir), 150);
+        return () => clearTimeout(timer);
+    }, [displayPosition, targetPosition]);
 
     // Methods
     const handleDiceRoll = (rollValue: number) => {
-        setPlayerPosition((prev) => Math.min(prev + rollValue, 100));
+        setTargetPosition((prev) => Math.min(prev + rollValue, 100));
     };
 
-    const handleTileEvent = (description: string, effect: string | null | undefined) => {
+    const handleTileEvent = useCallback((effect: string | null | undefined) => {
         if (effect) {
             const [action, value] = effect.split(":");
             switch (action) {
                 case "forward":
-                    setPlayerPosition((prev) => Math.min(prev + parseInt(value, 10), 100));
+                    setTargetPosition((prev) => Math.min(prev + parseInt(value, 10), 100));
                     break;
                 case "backward":
-                    setPlayerPosition((prev) => Math.max(prev - parseInt(value, 10), 1));
+                    setTargetPosition((prev) => Math.max(prev - parseInt(value, 10), 1));
                     break;
                 case "skip":
                     break;
                 case "finish":
-                    setCurrentTileEffect(null);
-                    setIsModalOpen(true);
                     break;
                 default:
                     break;
             }
         }
-    };
+    }, []);
 
-    const closeModal = () => {
-        const description = currentTileDescription;
+    const closeModal = useCallback(() => {
         const effect = currentTileEffect;
 
         setIsModalOpen(false);
@@ -70,10 +74,24 @@ function BoardGame() {
         setCurrentTileDescription("");
         setCurrentTileEffect(null);
 
-        if (description) {
-            handleTileEvent(description, effect);
-        }
-    };
+        handleTileEvent(effect);
+    }, [currentTileEffect, handleTileEvent]);
+
+    // Keyboard navigation
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent) => {
+            if (e.code === "Escape" && isModalOpen) {
+                closeModal();
+            } else if ((e.code === "Space" || e.code === "Enter") && !isModalOpen && displayPosition === targetPosition) {
+                e.preventDefault();
+                diceRef.current?.roll();
+            }
+        };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [isModalOpen, closeModal, displayPosition, targetPosition]);
+
+    const isAnimating = displayPosition !== targetPosition;
 
     return (
         <div className="BoardGame">
@@ -83,27 +101,30 @@ function BoardGame() {
             <div className="info-container" >
                 <div>
                     <p className="tag-title">Bukit Selidang</p>
-                    <h2>“El Nido de donde proviene <br />la luz de la Luna”</h2>
+                    <h2>"El Nido de donde proviene <br />la luz de la Luna"</h2>
                     <p className="subtitle">Travesía por la meseta del Usun Apau <br /> Sarawak, Borneo. 1992</p>
                 </div>
 
                 <div>
-                    <Dice onRoll={handleDiceRoll} disabled={isModalOpen} />
-                    {/* <p className="subtitle">Celda número: {playerPosition}</p> */}
+                    <Dice ref={diceRef} onRoll={handleDiceRoll} disabled={isModalOpen || isAnimating} />
                 </div>
 
                 <img className='abuelo' src={abuelo} alt="abuelo" />
             </div>
 
             <div className="board-wrapper">
-                <Board playerPosition={playerPosition} />
+                <Board playerPosition={displayPosition} />
             </div>
 
             <Modal isOpen={isModalOpen} onClose={closeModal}>
                 <div className="event-message markdown-content">
                     <p className="journal-page-title">{currentTileTitle}</p>
                     <ReactMarkdown>{currentTileDescription}</ReactMarkdown>
-                    <ReactMarkdown className="markdown-tag">{currentTileEffectText}</ReactMarkdown>
+                    {currentTileEffectText && (
+                        <div className={`effect-badge${currentTileEffect ? ` effect-badge--${currentTileEffect.split(":")[0]}` : ""}`}>
+                            <ReactMarkdown>{currentTileEffectText}</ReactMarkdown>
+                        </div>
+                    )}
                 </div>
             </Modal>
         </div>


### PR DESCRIPTION
  - Token steps tile-by-tile (150ms/step) instead of teleporting
  - Space/Enter rolls dice, Escape closes modal
  - Effect text shown as color-coded badge (green/red/grey/blue)